### PR TITLE
docs(wiki): add 3 insights from Story #206841 session

### DIFF
--- a/wiki/_index.md
+++ b/wiki/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Wiki Index
-updated: 2026-06-17
-page_count: 5
+updated: 2026-06-18
+page_count: 8
 ---
 
 # Wiki Index
@@ -43,6 +43,9 @@ _No projects yet._
 
 - [[Vercel Project casacolinacare-com]]
 - [[git worktree remove Requires --force for Claude Code Worktrees]]
+- [[ADO MCP wit_add_work_item_comment Parameter Names]]
+- [[RTL queryByText Regression Guards Must Target Unique Strings]]
+- [[RTL getAllByRole Returns All Headings Across Full Page Not Just Section]]
 
 ## Sources
 

--- a/wiki/code/ADO MCP wit_add_work_item_comment Parameter Names.md
+++ b/wiki/code/ADO MCP wit_add_work_item_comment Parameter Names.md
@@ -1,0 +1,45 @@
+---
+title: "ADO MCP wit_add_work_item_comment Parameter Names"
+type: code
+tags: [ado, mcp, tools, api]
+status: confirmed
+created: 2026-06-18
+updated: 2026-06-18
+source_count: 1
+aliases: [wit_add_work_item_comment, ado comment tool params]
+---
+
+# ADO MCP wit_add_work_item_comment Parameter Names
+
+The `mcp__azure-devops__wit_add_work_item_comment` tool uses non-obvious parameter names that differ from other `wit_*` tools.
+
+## Correct call
+
+```json
+{
+  "workItemId": 206841,   // number, minimum 1 — NOT "id"
+  "comment":   "...",     // string — NOT "text"
+  "format":    "Markdown" // optional, defaults to "Markdown"
+}
+```
+
+## Wrong call (silent validation error)
+
+```json
+{ "id": 206841, "text": "..." }
+}
+```
+
+Fails with: `Expected number, received nan` on `workItemId` and `Required` on `comment`. The error appears in tool output but the comment is silently dropped — the work item is unchanged with no other indication of failure.
+
+## Note
+
+The tool also sometimes times out (`MCP error -32001: Request timed out`) under load. This is transient — retry once before escalating.
+
+## Related
+
+- [[ADO Work Item Terminal State Is Closed Not Done]]
+
+## Sources
+
+- Session: Story #206841 implementation (2026-06-18)

--- a/wiki/code/RTL getAllByRole Returns All Headings Across Full Page Not Just Section.md
+++ b/wiki/code/RTL getAllByRole Returns All Headings Across Full Page Not Just Section.md
@@ -1,0 +1,56 @@
+---
+title: "RTL getAllByRole Returns All Headings Across the Full Page, Not Just One Section"
+type: code
+tags: [testing, rtl, vitest, react-testing-library, accessibility, headings]
+status: confirmed
+created: 2026-06-18
+updated: 2026-06-18
+source_count: 1
+aliases: [getAllByRole heading index, rtl heading position]
+---
+
+# RTL getAllByRole Returns All Headings Across the Full Page, Not Just One Section
+
+`screen.getAllByRole('heading', { level: 3 })` returns every h3 on the entire rendered page — not just those in the section you're testing. Index-based queries silently fail when other sections render h3s before the one you intend.
+
+## The failure mode
+
+The About page renders h3s in this order across all sections:
+
+| Index | Text | Section |
+|---|---|---|
+| 0 | Aloha Spirit | values |
+| 1 | Dignity & Independence | values |
+| 2 | Family First | values |
+| 3 | Community Connection | values |
+| 4 | Mari Kriss C. Aseniero | team |
+| 5 | Aileen Jordan, RN | team |
+| 6 | Care Team Member | team |
+
+```ts
+// FAILS — headings[1] is "Dignity & Independence", not the nurse card
+const headings = screen.getAllByRole('heading', { level: 3 });
+expect(headings[1]).toHaveTextContent('Aileen Jordan, RN');
+// Received: "Dignity & Independence"
+```
+
+## Fix: query by accessible name
+
+```ts
+// PASSES — finds the specific h3 by accessible name, position-independent
+expect(
+  screen.getByRole('heading', { level: 3, name: 'Aileen Jordan, RN' })
+).toBeInTheDocument();
+```
+
+## Rule
+
+Never assume heading index == card position. Always use `getByRole('heading', { name: '...' })` when targeting a specific heading by content. Index-based heading queries are brittle and break any time the page gains a new section above the target.
+
+## Related
+
+- [[RTL queryByText Regression Guards Must Target Unique Strings]]
+
+## Sources
+
+- Session: Story #206841 implementation (2026-06-18)

--- a/wiki/code/RTL queryByText Regression Guards Must Target Unique Strings.md
+++ b/wiki/code/RTL queryByText Regression Guards Must Target Unique Strings.md
@@ -1,0 +1,53 @@
+---
+title: "RTL queryByText Regression Guards Must Target Unique Strings"
+type: code
+tags: [testing, rtl, vitest, react-testing-library, regression]
+status: confirmed
+created: 2026-06-18
+updated: 2026-06-18
+source_count: 1
+aliases: [queryByText regression, not.toBeInTheDocument unique]
+---
+
+# RTL queryByText Regression Guards Must Target Unique Strings
+
+`queryByText(str).not.toBeInTheDocument()` fails if ANY node in the DOM still contains that string — even a different component that legitimately uses the same text.
+
+## The failure mode
+
+The About page has three team cards. Only `team[1]` was updated from `'Care Team Member'` to `'Aileen Jordan, RN'`. `team[2]` still has `name: 'Care Team Member'`.
+
+```ts
+// FAILS — team[2] still has "Care Team Member" in its h3
+expect(screen.queryByText('Care Team Member')).not.toBeInTheDocument();
+```
+
+Error: `expected document not to contain element, found <h3 ...>Care Team Member</h3>`
+
+## Fix 1: target strings unique to the changed element
+
+```ts
+// PASSES — "Lead Caregiver" only ever existed on team[1]
+expect(screen.queryByText('Lead Caregiver')).not.toBeInTheDocument();
+```
+
+## Fix 2: query by accessible name when the text must be exact
+
+```ts
+// PASSES — queries the h3 whose accessible name matches exactly
+expect(
+  screen.getByRole('heading', { level: 3, name: 'Aileen Jordan, RN' })
+).toBeInTheDocument();
+```
+
+## Rule
+
+Before writing `.not.toBeInTheDocument()` for a string, grep the component for that string and confirm it appears in exactly ONE place after your change. If it still appears elsewhere, switch to Fix 1 (unique string) or Fix 2 (role + name query).
+
+## Related
+
+- [[RTL getAllByRole Returns All Headings Across Full Page Not Just Section]]
+
+## Sources
+
+- Session: Story #206841 implementation (2026-06-18)


### PR DESCRIPTION
## Summary

3 new wiki entries extracted from the Story #206841 (Aileen Jordan, RN) implementation session.

- **ADO MCP `wit_add_work_item_comment` Parameter Names** — correct params are `workItemId` (number) and `comment` (string); wrong params fail silently
- **RTL `queryByText` Regression Guards Must Target Unique Strings** — `.not.toBeInTheDocument()` fails if any other DOM node shares the string; target unique strings or use `getByRole` with `name`
- **RTL `getAllByRole` Returns All Headings Across Full Page** — index-based heading queries break when other sections render h3s before your target; use `getByRole('heading', { name: '...' })` instead

## Test plan

- [x] Wiki markdown files are valid frontmatter + body
- [x] `_index.md` updated (page_count 5 → 8, 3 new `[[links]]` under Code)
- [x] Cross-links between the two RTL entries wired
- [x] lint + type-check pass (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7p8J6dJ24qABVkUdGRCZA