### PR TITLE
docs(wiki): add 3 insights from Story #206950 session

### DIFF
--- a/wiki/_index.md
+++ b/wiki/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Wiki Index
-updated: 2026-06-18
-page_count: 8
+updated: 2026-06-19
+page_count: 9
 ---
 
 # Wiki Index
@@ -46,6 +46,7 @@ _No projects yet._
 - [[ADO MCP wit_add_work_item_comment Parameter Names]]
 - [[RTL queryByText Regression Guards Must Target Unique Strings]]
 - [[RTL getAllByRole Returns All Headings Across Full Page Not Just Section]]
+- [[EnterWorktree path Switches Active Session Between Worktrees]]
 
 ## Sources
 

--- a/wiki/_log.md
+++ b/wiki/_log.md
@@ -4,6 +4,16 @@ title: Wiki Log
 
 # Wiki Log
 
+## 2026-06-19 — Insights (Session: Story #206950)
+
+- **Operation**: insights
+- **Source**: jx-kb:insights from conversation session
+- **Pages added**: 1
+  - `code/EnterWorktree path Switches Active Session Between Worktrees.md`
+- **Pages updated**: 2
+  - `code/ADO MCP wit_add_work_item_comment Parameter Names.md` — added background-session `project` param requirement
+  - `code/Vercel Project casacolinacare-com.md` — added deployment monitoring workflow
+
 ## 2026-06-17 — Insights (Session: Story #206771)
 
 - **Operation**: insights

--- a/wiki/code/ADO MCP wit_add_work_item_comment Parameter Names.md
+++ b/wiki/code/ADO MCP wit_add_work_item_comment Parameter Names.md
@@ -4,8 +4,8 @@ type: code
 tags: [ado, mcp, tools, api]
 status: confirmed
 created: 2026-06-18
-updated: 2026-06-18
-source_count: 1
+updated: 2026-06-19
+source_count: 2
 aliases: [wit_add_work_item_comment, ado comment tool params]
 ---
 
@@ -32,6 +32,21 @@ The `mcp__azure-devops__wit_add_work_item_comment` tool uses non-obvious paramet
 
 Fails with: `Expected number, received nan` on `workItemId` and `Required` on `comment`. The error appears in tool output but the comment is silently dropped — the work item is unchanged with no other indication of failure.
 
+## Background session: project param required
+
+In a background session (no TTY), omitting the `project` parameter causes silent cancellation — the tool returns `"Project selection cancelled"` and no comment is posted.
+
+Always include `project` explicitly:
+
+```json
+{
+  "workItemId": 206950,
+  "project":    "CasaColinaCare.com",
+  "comment":    "...",
+  "format":     "Markdown"
+}
+```
+
 ## Note
 
 The tool also sometimes times out (`MCP error -32001: Request timed out`) under load. This is transient — retry once before escalating.
@@ -43,3 +58,4 @@ The tool also sometimes times out (`MCP error -32001: Request timed out`) under 
 ## Sources
 
 - Session: Story #206841 implementation (2026-06-18)
+- Session: Story #206950 implementation (2026-06-19)

--- a/wiki/code/EnterWorktree path Switches Active Session Between Worktrees.md
+++ b/wiki/code/EnterWorktree path Switches Active Session Between Worktrees.md
@@ -1,0 +1,50 @@
+---
+title: "EnterWorktree path Switches Active Session Between Worktrees"
+type: code
+tags: [worktree, claude-code, background-session, isolation]
+status: confirmed
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [EnterWorktree path, switch worktree mid-session]
+---
+
+# EnterWorktree path Switches Active Session Between Worktrees
+
+When a background session starts in one worktree (e.g., a `study-library` worktree) and needs to implement in a different worktree (e.g., `impl-206950`), call `EnterWorktree` with the `path` parameter — not `name` — to switch mid-session.
+
+## Usage
+
+```json
+EnterWorktree({ "path": "/Users/jairo/Projects/casacolinacare.com/.claude/worktrees/impl-206950" })
+```
+
+The path must appear in `git worktree list` for the current repo.
+
+## Behavior after switch
+
+- All file edits target the new worktree
+- The old worktree is left on disk untouched
+- `ExitWorktree` will **not** auto-remove a worktree entered via `path` — use `action: "keep"` to return to the original directory
+
+## Symptom that triggers this
+
+Trying to edit a shared-checkout path while isolated in another worktree returns:
+
+> Edit the worktree copy of this file instead of the shared-checkout path.
+
+Or editing a path in worktree A while the session is isolated in worktree B returns:
+
+> This session is now isolated in /path/to/worktree-A. Edit the worktree copy of this file instead.
+
+## Fix
+
+Call `EnterWorktree({ path: "/absolute/path/to/target/worktree" })` before the first edit that targets the new worktree.
+
+## Related
+
+- [[git worktree remove Requires --force for Claude Code Worktrees]]
+
+## Sources
+
+- Session: Story #206950 — switched from `study-library` worktree to `impl-206950` mid-session (2026-06-19)

--- a/wiki/code/Vercel Project casacolinacare-com.md
+++ b/wiki/code/Vercel Project casacolinacare-com.md
@@ -3,8 +3,8 @@ title: "Vercel Project — casacolinacare-com"
 type: code
 tags: [vercel, deployment, casacolinacare]
 created: 2026-06-17
-updated: 2026-06-17
-source_count: 1
+updated: 2026-06-19
+source_count: 2
 aliases: [vercel casacolinacare, casacolinacare vercel]
 ---
 
@@ -32,6 +32,31 @@ MCP-accessible Vercel project for the Casa Colina Care marketing website.
 
 Use `mcp__vercel__*` tools with `teamId: team_a0HxSoTHUsrDilHfzDZfvQ2g` and `projectId: prj_RF8zLE6hbmTDR3LXbPiIkmJV5dS2`.
 
+## Monitoring a production deploy
+
+To confirm a PR merged to main deployed successfully, use this chain:
+
+```
+1. list_teams()
+   → teamId: "team_a0HxSoTHUsrDilHfzDZfvQ2g"
+
+2. list_projects(teamId)
+   → projectId: "prj_RF8zLE6hbmTDR3LXbPiIkmJV5dS2"
+
+3. list_deployments(projectId, teamId)
+   → deployments[0] is the most recent
+```
+
+A production deploy is confirmed when `deployments[0]` shows:
+
+| Field | Expected value |
+|-------|----------------|
+| `state` | `"READY"` |
+| `target` | `"production"` |
+| `meta.githubCommitRef` | `"main"` |
+
+The `meta.githubCommitMessage` identifies which PR triggered the deployment. `state: "ERROR"` means the build failed — check `get_deployment_build_logs(deploymentId, teamId)`.
+
 ## Related
 
 - [[GitHub Auto-Update Branch Can Break TypeScript Build]]
@@ -40,3 +65,4 @@ Use `mcp__vercel__*` tools with `teamId: team_a0HxSoTHUsrDilHfzDZfvQ2g` and `pro
 ## Sources
 
 - Session: Vercel build error investigation on PR #51 (2026-06-17)
+- Session: Story #206950 — monitored PR #56 production deploy (2026-06-19)


### PR DESCRIPTION
## Summary

- **Updated** `code/ADO MCP wit_add_work_item_comment Parameter Names.md` — added background-session `project` param requirement (silent cancellation without it)
- **New** `code/EnterWorktree path Switches Active Session Between Worktrees.md` — how to switch between worktrees mid-session using the `path` parameter
- **Updated** `code/Vercel Project casacolinacare-com.md` — added deployment monitoring workflow (`list_teams → list_projects → list_deployments`)

## Test plan

- [ ] Wiki pages render correctly in ADO wiki preview
- [ ] `_index.md` page count updated to 9, new page listed under Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7p8J6dJ24qABVkUdGRCZA