### PR TITLE
fix: update business phone to +1 (808) 444-1168 (AB#206975)

### DIFF
--- a/memory/people/kriss-aseniero.md
+++ b/memory/people/kriss-aseniero.md
@@ -8,7 +8,7 @@
 Runs the residential care home in Hawaii Kai. The website's contact form sends inquiries directly to her email. She is the business stakeholder — Ramon builds the site for her.
 
 ## Contact Info (Business)
-- Phone: +1 (808) 200-1840
+- Phone: +1 (808) 444-1168
 - Fax: +1 (808) 670-1163
 - Email: kriss@casacolinacare.com
 - Address: 189 Anapalau Street (Hawaii Kai), Honolulu, HI 96825

--- a/scratchpad/update-site-business-phone-to-1-808-444-1168_206975_plan.md
+++ b/scratchpad/update-site-business-phone-to-1-808-444-1168_206975_plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Update site business phone to +1 (808) 444-1168
+
+**Story ID:** #206975
+**Feature:** none — standalone story
+**Date:** 2026-06-19
+**State:** New  |  **Points:** 1
+
+---
+
+## Story Summary
+
+**Narrative:**
+As a prospective resident's family member, I want the Casa Colina Care site to display the
+correct business phone number (+1 (808) 444-1168) on every page, So that I can call and
+reach the care home without hitting a wrong number.
+
+**Acceptance Criteria:**
+1. The footer displays `+1 (808) 444-1168` with `href="tel:+18084441168"` on all pages
+2. The CTA banner displays `+1 (808) 444-1168` with `href="tel:+18084441168"` (Home, About, FAQ)
+3. The Contact page displays `+1 (808) 444-1168` with `href="tel:+18084441168"`
+4. The FAQ admissions answer text includes `+1 (808) 444-1168`
+5. The JSON-LD structured data `telephone` field is `+18084441168`
+6. The old number `+1 (808) 200-1840` / `+18082001840` does not appear in `src/` or `tests/`
+7. Fax number `+1 (808) 670-1163` is unchanged
+
+---
+
+## Scope
+
+What this plan covers:
+- Replace display string `+1 (808) 200-1840` → `+1 (808) 444-1168` in all 5 source files
+- Replace E.164 href `tel:+18082001840` → `tel:+18084441168` in all source files
+- Update 5 unit test files and 3 e2e spec files that assert the old number
+- Update memory file `memory/people/kriss-aseniero.md` phone field
+
+What this plan does NOT cover:
+- Centralizing phone into `constants.ts` (known issue #4, separate story)
+- Fax number `+1 (808) 670-1163` / `+18086701163` (untouched by design)
+- Historical docs under `prds/**` and `progress.txt` (frozen record)
+
+---
+
+## Code Touchpoints
+
+Files and modules relevant to this story:
+
+| File / Module | Relevance |
+|---------------|-----------|
+| `src/lib/structured-data.ts:7` | JSON-LD `telephone` field — E.164 format, AC #5 |
+| `src/components/layout/footer.tsx:52,55` | Footer phone link + display text, AC #1 |
+| `src/components/sections/cta-banner.tsx:31,34` | CTA banner phone link + display text, AC #2 |
+| `src/app/contact/page.tsx:72,75` | Contact page phone link + display text, AC #3 |
+| `src/lib/faq-data.ts:38` | FAQ admissions answer inline text, AC #4 |
+| `tests/unit/contact-page.test.tsx` | Asserts `href="tel:+18082001840"` → must update |
+| `tests/unit/footer.test.tsx` | Asserts href + display text → must update |
+| `tests/unit/cta-banner.test.tsx` | Asserts display + href → must update |
+| `tests/unit/structured-data.test.ts` | Asserts `telephone` value → must update |
+| `tests/unit/faq-page.test.tsx` | Asserts admissions answer text → must update |
+| `tests/e2e/structured-data.spec.ts` | E2E asserts JSON-LD telephone → must update |
+| `tests/e2e/footer-contact.spec.ts` | E2E asserts footer phone link → must update |
+| `tests/e2e/contact-info.spec.ts` | E2E asserts contact page phone link → must update |
+| `memory/people/kriss-aseniero.md:11` | Kriss's profile phone field → keep in sync |
+
+---
+
+## Approach
+
+High-level implementation strategy:
+
+1. **Source edits** — replace both formats in 5 source files:
+   - `+1 (808) 200-1840` → `+1 (808) 444-1168` (display string)
+   - `tel:+18082001840` → `tel:+18084441168` (href attribute)
+   - `'+18082001840'` → `'+18084441168'` (JS string in structured-data.ts)
+2. **Test updates** — update 8 test files so assertions point to the new number (same two formats)
+3. **Memory file** — update `memory/people/kriss-aseniero.md` phone field
+4. **Health check** — run `npm run lint -- --fix && npm run type-check && npm test -- --run`
+5. **Verify clean** — `grep -rE "200[-. ]?1840|18082001840" src tests` must return empty; fax `670-1163` still present
+
+Key decisions:
+- Phone is NOT centralized — in-place replacement per file, matching the pattern of PRDs 004 and 005
+- Two formats must both be updated: display `(808) 444-1168` and E.164 `+18084441168`
+- Tests assert exact strings — update assertions, do NOT delete tests
+
+---
+
+## Dependencies
+
+| Dependency | Type | Notes |
+|------------|------|-------|
+| None | — | No external dependencies identified. Purely a string replacement. |
+
+---
+
+## Test Plan per AC
+
+| AC | Test Type | File | Scenario |
+|----|-----------|------|----------|
+| AC 1: footer `+1 (808) 444-1168` + `tel:+18084441168` | Unit + E2E | `footer.test.tsx`, `footer-contact.spec.ts` | Render Footer → assert link text and href contain new number; old number absent |
+| AC 2: CTA banner `+1 (808) 444-1168` + `tel:+18084441168` | Unit | `cta-banner.test.tsx` | Render CtaBanner → assert display text and tel: href contain new number |
+| AC 3: Contact page `+1 (808) 444-1168` + `tel:+18084441168` | Unit + E2E | `contact-page.test.tsx`, `contact-info.spec.ts` | Render ContactPage → assert link text and href; E2E navigates to /contact |
+| AC 4: FAQ admissions text includes `+1 (808) 444-1168` | Unit | `faq-page.test.tsx` | Render FAQ data → assert admissions answer string contains new number |
+| AC 5: JSON-LD `telephone` = `+18084441168` | Unit + E2E | `structured-data.test.ts`, `structured-data.spec.ts` | Parse JSON-LD → assert telephone field equals new E.164 |
+| AC 6: old number absent from `src/` and `tests/` | Grep verification | all | `grep -rE "200[-. ]?1840|18082001840" src tests` returns empty |
+| AC 7: fax `+1 (808) 670-1163` unchanged | Grep spot-check | `footer.tsx`, `contact/page.tsx`, `structured-data.ts` | `grep 670-1163` still returns 3 matches |
+
+---
+
+## Open Questions
+
+No open questions. All file locations, line numbers, and replacement values are precisely known.

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -69,10 +69,10 @@ export default function ContactPage() {
                   <div>
                     <p className="font-medium">Phone</p>
                     <a
-                      href="tel:+18082001840"
+                      href="tel:+18084441168"
                       className="text-muted-foreground transition-colors hover:text-primary"
                     >
-                      +1 (808) 200-1840
+                      +1 (808) 444-1168
                     </a>
                   </div>
                 </div>

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -49,10 +49,10 @@ export function Footer() {
             <div className="mt-3 space-y-2 text-sm text-muted-foreground">
               <p>
                 <a
-                  href="tel:+18082001840"
+                  href="tel:+18084441168"
                   className="transition-colors hover:text-primary"
                 >
-                  +1 (808) 200-1840
+                  +1 (808) 444-1168
                 </a>
               </p>
               <p>

--- a/src/components/sections/cta-banner.tsx
+++ b/src/components/sections/cta-banner.tsx
@@ -28,10 +28,10 @@ export function CtaBanner({
         )}
         <div className="mt-8 flex flex-col items-center justify-center gap-4 text-primary-foreground/90 sm:flex-row sm:gap-8">
           <a
-            href="tel:+18082001840"
+            href="tel:+18084441168"
             className="transition-colors hover:text-primary-foreground"
           >
-            +1 (808) 200-1840
+            +1 (808) 444-1168
           </a>
           <a
             href="mailto:kriss@casacolinacare.com"

--- a/src/lib/faq-data.ts
+++ b/src/lib/faq-data.ts
@@ -35,7 +35,7 @@ export const faqCategories: FaqCategory[] = [
       {
         question: 'How do I begin the admissions process?',
         answer:
-          'The first step is to schedule a consultation by calling us at +1 (808) 200-1840, emailing kriss@casacolinacare.com, or filling out our contact form. We\u2019ll arrange a visit so you can tour our home and meet our team.',
+          'The first step is to schedule a consultation by calling us at +1 (808) 444-1168, emailing kriss@casacolinacare.com, or filling out our contact form. We\u2019ll arrange a visit so you can tour our home and meet our team.',
       },
       {
         question: 'What should I expect during a tour or consultation?',

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -4,7 +4,7 @@ export const jsonLd = {
   name: 'Casa Colina Care',
   description: 'Compassionate care home in Hawaii Kai, Hawaii',
   url: 'https://casacolinacare.com',
-  telephone: '+18082001840',
+  telephone: '+18084441168',
   faxNumber: '+18086701163',
   email: 'kriss@casacolinacare.com',
   address: {

--- a/tests/e2e/contact-info.spec.ts
+++ b/tests/e2e/contact-info.spec.ts
@@ -9,9 +9,9 @@ test.describe('Contact Page — Phone, Fax, and Address', () => {
     page,
   }) => {
     const main = page.locator('main');
-    const phoneLink = main.locator('a[href="tel:+18082001840"]');
+    const phoneLink = main.locator('a[href="tel:+18084441168"]');
     await expect(phoneLink).toBeVisible();
-    await expect(phoneLink).toContainText('+1 (808) 200-1840');
+    await expect(phoneLink).toContainText('+1 (808) 444-1168');
   });
 
   test('TC-016: fax is visible but not clickable (not a link)', async ({

--- a/tests/e2e/footer-contact.spec.ts
+++ b/tests/e2e/footer-contact.spec.ts
@@ -9,9 +9,9 @@ test.describe('Footer — Phone, Fax, and Address (US-003)', () => {
     page,
   }) => {
     const footer = page.getByRole('contentinfo');
-    const phoneLink = footer.locator('a[href="tel:+18082001840"]');
+    const phoneLink = footer.locator('a[href="tel:+18084441168"]');
     await expect(phoneLink).toBeVisible();
-    await expect(phoneLink).toContainText('+1 (808) 200-1840');
+    await expect(phoneLink).toContainText('+1 (808) 444-1168');
   });
 
   test('TC-029: footer fax is visible but not a link', async ({ page }) => {

--- a/tests/e2e/structured-data.spec.ts
+++ b/tests/e2e/structured-data.spec.ts
@@ -10,7 +10,7 @@ test.describe('Schema.org Structured Data', () => {
     const jsonLd = JSON.parse(scriptContent!);
 
     // Telephone
-    expect(jsonLd.telephone).toBe('+18082001840');
+    expect(jsonLd.telephone).toBe('+18084441168');
 
     // Fax number
     expect(jsonLd.faxNumber).toBe('+18086701163');

--- a/tests/unit/contact-page.test.tsx
+++ b/tests/unit/contact-page.test.tsx
@@ -8,9 +8,9 @@ describe('Contact Page — Phone, Fax, and Address (US-002)', () => {
     render(<ContactPage />);
   });
 
-  test('TC-004: phone link href is tel:+18082001840', () => {
-    const phoneLink = screen.getByRole('link', { name: /808.*200.*1840/ });
-    expect(phoneLink).toHaveAttribute('href', 'tel:+18082001840');
+  test('TC-004: phone link href is tel:+18084441168', () => {
+    const phoneLink = screen.getByRole('link', { name: /808.*444.*1168/ });
+    expect(phoneLink).toHaveAttribute('href', 'tel:+18084441168');
   });
 
   test('TC-005: fax renders as plain text, not a link', () => {

--- a/tests/unit/cta-banner.test.tsx
+++ b/tests/unit/cta-banner.test.tsx
@@ -4,9 +4,9 @@ import { describe, expect, test } from 'vitest';
 import { CtaBanner } from '@/components/sections/cta-banner';
 
 describe('CtaBanner — Phone Number Regression (US-005-02)', () => {
-  test('AC-005-07: displays correct phone number +1 (808) 200-1840', () => {
+  test('AC-005-07: displays correct phone number +1 (808) 444-1168', () => {
     render(<CtaBanner />);
-    expect(screen.getByText('+1 (808) 200-1840')).toBeInTheDocument();
+    expect(screen.getByText('+1 (808) 444-1168')).toBeInTheDocument();
   });
 
   test('AC-005-08: old placeholder +1 (800) 888-8888 is NOT present', () => {
@@ -16,10 +16,10 @@ describe('CtaBanner — Phone Number Regression (US-005-02)', () => {
     expect(body).not.toContain('(800) 888-8888');
   });
 
-  test('AC-005-09: tel: link has href="tel:+18082001840"', () => {
+  test('AC-005-09: tel: link has href="tel:+18084441168"', () => {
     render(<CtaBanner />);
-    const phoneLink = screen.getByRole('link', { name: /808.*200.*1840/ });
-    expect(phoneLink).toHaveAttribute('href', 'tel:+18082001840');
+    const phoneLink = screen.getByRole('link', { name: /808.*444.*1168/ });
+    expect(phoneLink).toHaveAttribute('href', 'tel:+18084441168');
   });
 
   test('AC-005-09: old tel href +18008888888 is NOT present', () => {

--- a/tests/unit/faq-page.test.tsx
+++ b/tests/unit/faq-page.test.tsx
@@ -24,7 +24,7 @@ describe('FAQ Page — Location & Phone Updates (US-004)', () => {
       ?.questions.find(q =>
         q.question.includes('How do I begin the admissions process'),
       )?.answer;
-    expect(admissionsAnswer).toContain('+1 (808) 200-1840');
+    expect(admissionsAnswer).toContain('+1 (808) 444-1168');
   });
 
   test('TC-F03: marketing Hawaii Kai references are preserved', () => {

--- a/tests/unit/footer.test.tsx
+++ b/tests/unit/footer.test.tsx
@@ -4,15 +4,15 @@ import { describe, expect, test } from 'vitest';
 import { Footer } from '@/components/layout/footer';
 
 describe('Footer — Phone, Fax, and Address (US-003)', () => {
-  test('TC-018: phone link href is tel:+18082001840', () => {
+  test('TC-018: phone link href is tel:+18084441168', () => {
     render(<Footer />);
-    const phoneLink = screen.getByRole('link', { name: /808.*200.*1840/ });
-    expect(phoneLink).toHaveAttribute('href', 'tel:+18082001840');
+    const phoneLink = screen.getByRole('link', { name: /808.*444.*1168/ });
+    expect(phoneLink).toHaveAttribute('href', 'tel:+18084441168');
   });
 
   test('TC-019: phone display text is correct', () => {
     render(<Footer />);
-    expect(screen.getByText('+1 (808) 200-1840')).toBeInTheDocument();
+    expect(screen.getByText('+1 (808) 444-1168')).toBeInTheDocument();
   });
 
   test('TC-020: fax entry exists with correct number', () => {

--- a/tests/unit/structured-data.test.ts
+++ b/tests/unit/structured-data.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from 'vitest';
 import { jsonLd } from '@/lib/structured-data';
 
 describe('Schema.org Structured Data', () => {
-  test('telephone is +18082001840', () => {
-    expect(jsonLd.telephone).toBe('+18082001840');
+  test('telephone is +18084441168', () => {
+    expect(jsonLd.telephone).toBe('+18084441168');
   });
 
   test('telephone is not the old value', () => {


### PR DESCRIPTION
## Summary

- Replace `+1 (808) 200-1840` / `+18082001840` with `+1 (808) 444-1168` / `+18084441168` across 5 source files (footer, CTA banner, contact page, FAQ data, JSON-LD structured data)
- Update 8 test files (5 unit + 3 e2e) to assert the new number
- Sync `memory/people/kriss-aseniero.md` phone field

Fax number `+1 (808) 670-1163` unchanged. All 179 unit tests pass. Lint and type-check clean.

Closes AB#206975

## Test plan

- [x] `npm run lint -- --fix` — warnings only (pre-existing), no errors
- [x] `npm run type-check` — clean
- [x] `npm test -- --run` — 179/179 pass
- [ ] E2E: `npm run test:e2e` — against a running dev server (run locally after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfDqqrvqqvD3WxVKtruKcB