### PR TITLE
test(e2e): fix about-founder assertion for full name Mari Kriss C. Aseniero

### DIFF
--- a/tests/e2e/about-founder.spec.ts
+++ b/tests/e2e/about-founder.spec.ts
@@ -5,7 +5,7 @@ test.describe('About Page — Founder Name (US-006-01)', () => {
     page,
   }) => {
     await page.goto('/about');
-    await expect(page.getByText('Kriss Aseniero')).toBeVisible();
+    await expect(page.getByText('Mari Kriss C. Aseniero')).toBeVisible();
     await expect(page.getByText('Kriss Judd')).toBeHidden();
   });
 


### PR DESCRIPTION
## Summary

- Fix `about-founder.spec.ts` — test expected `Kriss Aseniero` but DOM renders `Mari Kriss C. Aseniero`; middle initial `C.` broke substring match
- Pre-existing failure caught by running E2E suite after phone number update (PR #58)

## Test plan

- [x] `npx playwright test tests/e2e/about-founder.spec.ts` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfDqqrvqqvD3WxVKtruKcB