### PR TITLE
docs(wiki): add 6 insights + lint fixes from phone-update session

### DIFF
--- a/tests/e2e/about-founder.spec.ts
+++ b/tests/e2e/about-founder.spec.ts
@@ -5,7 +5,7 @@ test.describe('About Page — Founder Name (US-006-01)', () => {
     page,
   }) => {
     await page.goto('/about');
-    await expect(page.getByText('Kriss Aseniero')).toBeVisible();
+    await expect(page.getByText('Mari Kriss C. Aseniero')).toBeVisible();
     await expect(page.getByText('Kriss Judd')).toBeHidden();
   });
 

--- a/wiki/_index.md
+++ b/wiki/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Wiki Index
-updated: 2026-06-18
-page_count: 8
+updated: 2026-06-19
+page_count: 14
 ---
 
 # Wiki Index
@@ -12,8 +12,10 @@ _No ideas yet._
 
 ## Concepts
 
-- [[Squash Merge Makes Branch Cleanup Require Force Delete]]
-- [[GitHub Auto-Update Branch Can Break TypeScript Build]]
+- [[After Squash Merge New Commits Need Cherry-Pick to Fresh Branch]] — after squash merge, use cherry-pick to fresh branch for follow-on commits, not rebase (#git, #squash-merge, #workflow)
+- [[Background Session Cannot Load MCP Servers Created After Session Start]] — .mcp.json created mid-session has no effect; fall back to az CLI (#claude-code, #mcp, #worktree)
+- [[GitHub Auto-Update Branch Can Break TypeScript Build]] — GitHub auto-merge can produce unused imports that break TypeScript strict build (#github, #typescript, #build)
+- [[Squash Merge Makes Branch Cleanup Require Force Delete]] — squash merge means `git branch -d` fails; always use `-D` after confirmed squash PR (#git, #squash-merge)
 
 ## Entities
 
@@ -37,15 +39,19 @@ _No projects yet._
 
 ## Decisions
 
-- [[ADO Work Item Terminal State Is Closed Not Done]]
+- [[ADO Work Item Terminal State Is Closed Not Done]] — terminal state for Stories and Tasks in this project is `Closed`, not `Done` (#ado, #workflow)
 
 ## Code
 
-- [[Vercel Project casacolinacare-com]]
-- [[git worktree remove Requires --force for Claude Code Worktrees]]
-- [[ADO MCP wit_add_work_item_comment Parameter Names]]
-- [[RTL queryByText Regression Guards Must Target Unique Strings]]
-- [[RTL getAllByRole Returns All Headings Across Full Page Not Just Section]]
+- [[az boards work-item CLI Uses --discussion Flag Not comment add]] — `az boards work-item update --discussion "..."` is correct; `comment add` subcommand does not exist (#ado, #cli)
+- [[ADO MCP wit_add_work_item_comment Parameter Names]] — use `workItemId` (not `id`) and `comment` (not `text`); wrong params silently drop the comment (#ado, #mcp)
+- [[gh pr merge Fails When Main Branch Is Checked Out in Another Worktree]] — use `gh api` directly when main is live in another worktree (#git, #worktree, #github)
+- [[GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN]] — empty bearer header → HTTP 400; fix: wire PAT into settings.json env block (#github, #mcp, #auth)
+- [[git worktree remove Requires --force for Claude Code Worktrees]] — Claude harness copies untracked hook files into every worktree; always use `--force` (#git, #worktree, #claude-code)
+- [[Playwright getByText Fails When Middle Initial Interrupts Name Substring]] — `getByText('Kriss Aseniero')` fails when DOM has `Mari Kriss C. Aseniero`; assert exact rendered string (#testing, #playwright)
+- [[RTL getAllByRole Returns All Headings Across Full Page Not Just Section]] — `getAllByRole('heading')` returns all headings on the full page; use `{ name: '...' }` not index (#testing, #rtl)
+- [[RTL queryByText Regression Guards Must Target Unique Strings]] — `.not.toBeInTheDocument()` fails if the string appears in ANY node; target unique strings only (#testing, #rtl)
+- [[Vercel Project casacolinacare-com]] — team/project IDs, deployment behavior, MCP access config (#vercel, #deployment)
 
 ## Sources
 

--- a/wiki/_log.md
+++ b/wiki/_log.md
@@ -4,6 +4,33 @@ title: Wiki Log
 
 # Wiki Log
 
+## 2026-06-19 — Lint
+
+- **Operation**: lint
+- **Errors found**: 0
+- **Warnings found**: 3 (2 orphan pages, 1 missing Related section)
+- **Info found**: 10 (8 missing index summaries, 1 missing prose wikilink, 1 missing RTL→Playwright cross-ref)
+- **Auto-fixes applied**: 4 (Related section added, RTL cross-ref added, prose wikilink added, 8 index summaries added)
+- **Health score**: 75/100 → **97/100** after fixes
+- **Outcome**: Report generated, all issues resolved
+
+## 2026-06-19 — Session Insights: phone-update + GitHub MCP fix
+
+- **Operation**: insights
+- **Label**: phone-update + GitHub MCP fix (2026-06-19)
+- **Pages created**: 6
+  - `code/gh pr merge Fails When Main Branch Is Checked Out in Another Worktree.md`
+  - `concepts/After Squash Merge New Commits Need Cherry-Pick to Fresh Branch.md`
+  - `code/az boards work-item CLI Uses --discussion Flag Not comment add.md`
+  - `code/Playwright getByText Fails When Middle Initial Interrupts Name Substring.md`
+  - `code/GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN.md`
+  - `concepts/Background Session Cannot Load MCP Servers Created After Session Start.md`
+- **Pages updated**: 1 (`concepts/Squash Merge Makes Branch Cleanup Require Force Delete.md` — added cross-refs)
+- **Ideas extracted**: 6
+- **Conflicts flagged**: 0
+- **Cross-references added**: 2
+- **Outcome**: Success
+
 ## 2026-06-17 — Insights (Session: Story #206771)
 
 - **Operation**: insights

--- a/wiki/code/GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN.md
+++ b/wiki/code/GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN.md
@@ -1,0 +1,61 @@
+---
+title: "GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN"
+type: code
+tags: [github, mcp, auth, claude-code, config]
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [github mcp 400, github mcp bearer token, GITHUB_PERSONAL_ACCESS_TOKEN]
+---
+
+# GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN
+
+The GitHub MCP server at `api.githubcopilot.com/mcp/` requires `Authorization: Bearer <token>`. If `GITHUB_PERSONAL_ACCESS_TOKEN` is not set in the environment, the header becomes `Authorization: Bearer ` (empty value), and the server returns HTTP 400.
+
+## Error
+
+```
+Failed to reconnect to plugin:github:github: HTTP 400 at https://api.githubcopilot.com/mcp/
+```
+
+## Fix
+
+Add the PAT to `~/.claude/settings.json` under `env`:
+
+```json
+{
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "github_pat_..."
+  }
+}
+```
+
+The GitHub plugin config at `~/.claude/plugins/cache/claude-plugins-official/github/unknown/.mcp.json` reads this env var:
+
+```json
+{
+  "github": {
+    "type": "http",
+    "url": "https://api.githubcopilot.com/mcp/",
+    "headers": {
+      "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    }
+  }
+}
+```
+
+## Generating a PAT
+
+GitHub → Settings → Developer settings → Personal access tokens → Fine-grained. Scope to the target repos. Verify with `curl -H "Authorization: Bearer <pat>" https://api.github.com/user` — expect HTTP 200.
+
+## Note
+
+A `401` from the PAT validation endpoint means the token itself is invalid or revoked. Generate a new one.
+
+## Related
+
+- [[Background Session Cannot Load MCP Servers Created After Session Start]]
+
+## Sources
+
+- Session: phone-update + GitHub MCP fix (2026-06-19)

--- a/wiki/code/Playwright getByText Fails When Middle Initial Interrupts Name Substring.md
+++ b/wiki/code/Playwright getByText Fails When Middle Initial Interrupts Name Substring.md
@@ -1,0 +1,40 @@
+---
+title: "Playwright getByText Fails When Middle Initial Interrupts Name Substring"
+type: code
+tags: [testing, playwright, e2e, selectors]
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [playwright getByText substring, middle initial test failure]
+---
+
+# Playwright getByText Fails When Middle Initial Interrupts Name Substring
+
+`page.getByText(str)` does a literal substring match. If the DOM renders a full name with a middle initial, a shorter version of the name without the initial will NOT match — even if both first and last name are present.
+
+## Example
+
+DOM renders: `Mari Kriss C. Aseniero`
+Test asserts: `page.getByText('Kriss Aseniero')`
+
+**Result: fails.** `Kriss Aseniero` is not a literal substring of `Mari Kriss C. Aseniero` — the `C.` sits between them.
+
+## Fix
+
+Assert the exact string as rendered in the DOM:
+
+```ts
+await expect(page.getByText('Mari Kriss C. Aseniero')).toBeVisible();
+```
+
+## Rule
+
+Before writing a `getByText` assertion, check what the component actually renders — not what you expect the name to be. Grep the source file for the exact string used in JSX.
+
+## Related
+
+- [[RTL queryByText Regression Guards Must Target Unique Strings]]
+
+## Sources
+
+- Session: phone-update + GitHub MCP fix (2026-06-19)

--- a/wiki/code/RTL queryByText Regression Guards Must Target Unique Strings.md
+++ b/wiki/code/RTL queryByText Regression Guards Must Target Unique Strings.md
@@ -47,6 +47,7 @@ Before writing `.not.toBeInTheDocument()` for a string, grep the component for t
 ## Related
 
 - [[RTL getAllByRole Returns All Headings Across Full Page Not Just Section]]
+- [[Playwright getByText Fails When Middle Initial Interrupts Name Substring]]
 
 ## Sources
 

--- a/wiki/code/az boards work-item CLI Uses --discussion Flag Not comment add.md
+++ b/wiki/code/az boards work-item CLI Uses --discussion Flag Not comment add.md
@@ -1,0 +1,44 @@
+---
+title: "az boards work-item CLI Uses --discussion Flag Not comment add"
+type: code
+tags: [ado, azure-devops, cli, az]
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [az boards comment, ado cli comment, az work-item discussion]
+---
+
+# az boards work-item CLI Uses --discussion Flag Not comment add
+
+`az boards work-item comment add` is not a valid subcommand. The correct way to post a comment on an ADO work item via the `az` CLI is the `--discussion` flag on `update`.
+
+## Wrong (fails)
+
+```bash
+az boards work-item comment add --id 206975 --comment "..."
+# ERROR: 'comment' is misspelled or not recognized by the system.
+```
+
+## Correct
+
+```bash
+az boards work-item update \
+  --id 206975 \
+  --org https://dev.azure.com/<org> \
+  --discussion "Your comment text here."
+```
+
+The `--discussion` flag appends a new discussion comment to the work item's history. The response includes `commentVersionRef.commentId` confirming the post.
+
+## Note
+
+This is the `az` CLI fallback pattern when [[ADO MCP wit_add_work_item_comment Parameter Names|MCP tools]] are unavailable (e.g., [[Background Session Cannot Load MCP Servers Created After Session Start|background sessions that started before `.mcp.json` was created]]).
+
+## Related
+
+- [[ADO MCP wit_add_work_item_comment Parameter Names]]
+- [[ADO Work Item Terminal State Is Closed Not Done]]
+
+## Sources
+
+- Session: phone-update + GitHub MCP fix (2026-06-19)

--- a/wiki/code/gh pr merge Fails When Main Branch Is Checked Out in Another Worktree.md
+++ b/wiki/code/gh pr merge Fails When Main Branch Is Checked Out in Another Worktree.md
@@ -1,0 +1,45 @@
+---
+title: "gh pr merge Fails When Main Branch Is Checked Out in Another Worktree"
+type: code
+tags: [git, worktree, github, cli]
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [gh pr merge worktree error, gh pr merge main already used]
+---
+
+# gh pr merge Fails When Main Branch Is Checked Out in Another Worktree
+
+`gh pr merge` internally tries to check out the PR's base branch locally after merging. If `main` is already checked out in another worktree, this step fails.
+
+## Error
+
+```
+fatal: 'main' is already used by worktree at '/Users/jairo/Projects/casacolinacare.com'
+```
+
+## Fix
+
+Use the GitHub REST API directly instead:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<num>/merge \
+  -X PUT \
+  -f merge_method=squash \
+  -f commit_title="fix: your commit title"
+```
+
+Returns `{"merged": true, "sha": "..."}` on success. Branch auto-deletion (if configured on the repo) still fires.
+
+## Why gh pr merge fails
+
+`gh pr merge` calls `git checkout main` locally to fast-forward the local copy. Worktrees lock branches — a branch checked out in any worktree cannot be checked out again elsewhere.
+
+## Related
+
+- [[Squash Merge Makes Branch Cleanup Require Force Delete]]
+- [[git worktree remove Requires --force for Claude Code Worktrees]]
+
+## Sources
+
+- Session: phone-update + GitHub MCP fix (2026-06-19)

--- a/wiki/concepts/After Squash Merge New Commits Need Cherry-Pick to Fresh Branch.md
+++ b/wiki/concepts/After Squash Merge New Commits Need Cherry-Pick to Fresh Branch.md
@@ -1,0 +1,46 @@
+---
+title: "After Squash Merge New Commits Need Cherry-Pick to Fresh Branch"
+type: concept
+tags: [git, squash-merge, worktree, workflow, cherry-pick]
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [squash merge cherry-pick, post-squash continuation]
+---
+
+# After Squash Merge New Commits Need Cherry-Pick to Fresh Branch
+
+After a PR is squash-merged, any additional commits on the original branch cannot be cleanly rebased onto `main` — git does not auto-skip the already-merged commits because the squash created a new SHA.
+
+## Symptom
+
+Attempting `git rebase origin/main` on a branch that has both squash-merged commits and new work will either replay the merged commits (duplication) or conflict, depending on how similar the changes are.
+
+## Correct Workflow
+
+```bash
+# 1. Find the SHA of only the NEW commit(s)
+git log --oneline fix/old-branch
+
+# 2. Create a clean branch from main
+git checkout -b fix/new-branch origin/main
+
+# 3. Cherry-pick only the new work
+git cherry-pick <new-commit-sha>
+
+# 4. Push and open a new PR
+git push -u origin fix/new-branch
+```
+
+## Why Rebase Fails
+
+A squash merge rewrites the branch's commit graph into a single new commit on `main`. The original commits' SHAs don't exist in `main`'s history, so `git rebase` sees them all as new work and tries to replay everything — including what was already merged.
+
+## Related
+
+- [[Squash Merge Makes Branch Cleanup Require Force Delete]]
+- [[gh pr merge Fails When Main Branch Is Checked Out in Another Worktree]]
+
+## Sources
+
+- Session: phone-update + GitHub MCP fix (2026-06-19)

--- a/wiki/concepts/Background Session Cannot Load MCP Servers Created After Session Start.md
+++ b/wiki/concepts/Background Session Cannot Load MCP Servers Created After Session Start.md
@@ -1,0 +1,40 @@
+---
+title: "Background Session Cannot Load MCP Servers Created After Session Start"
+type: concept
+tags: [claude-code, mcp, worktree, background-session, config]
+created: 2026-06-19
+updated: 2026-06-19
+source_count: 1
+aliases: [mcp not loading background session, .mcp.json retroactive]
+---
+
+# Background Session Cannot Load MCP Servers Created After Session Start
+
+MCP server configuration in `.mcp.json` is read once at session startup. A background session that starts before `.mcp.json` exists will never see those servers — even if the file is created mid-session.
+
+## Constraint 1: MCP servers don't load retroactively
+
+Creating `.mcp.json` during a running background session has no effect on that session. The ADO MCP server (or any other) will not appear in tool lists. Workaround: fall back to `az` CLI or other non-MCP tooling for that session.
+
+## Constraint 2: Background session worktree guard blocks writes to the main checkout
+
+Background worktree sessions enforce isolation. File edits outside `.claude/worktrees/` are rejected until `EnterWorktree` is called. Config files that must land in the main checkout (like `.mcp.json`) cannot be written by the background session itself.
+
+Workaround: user creates the file via terminal using the `!` command prefix:
+
+```bash
+! echo '{"mcpServers": {"ado": {"command": "npx", "args": ["-y", "@azure-devops/mcp", "jairo"]}}}' > .mcp.json
+```
+
+## Takeaway
+
+For MCP-dependent workflows, ensure `.mcp.json` exists **before** starting the session. If running a background job that needs ADO MCP, start a fresh session after the config file is in place.
+
+## Related
+
+- [[GitHub MCP HTTP 400 Caused by Unset GITHUB_PERSONAL_ACCESS_TOKEN]]
+- [[az boards work-item CLI Uses --discussion Flag Not comment add]]
+
+## Sources
+
+- Session: phone-update + GitHub MCP fix (2026-06-19)

--- a/wiki/concepts/Squash Merge Makes Branch Cleanup Require Force Delete.md
+++ b/wiki/concepts/Squash Merge Makes Branch Cleanup Require Force Delete.md
@@ -44,6 +44,8 @@ The B5 "already merged" check (`git merge-base --is-ancestor`) will return false
 ## Related
 
 - [[git worktree remove Requires --force for Claude Code Worktrees]]
+- [[After Squash Merge New Commits Need Cherry-Pick to Fresh Branch]]
+- [[gh pr merge Fails When Main Branch Is Checked Out in Another Worktree]]
 
 ## Sources
 


### PR DESCRIPTION
## Summary

- 6 new wiki pages from phone-update + GitHub MCP fix session (gh pr merge worktree conflict, squash cherry-pick, az boards `--discussion`, Playwright middle-initial substring, GitHub MCP HTTP 400, background session MCP load)
- Lint auto-fixes: cross-refs, 8 index summaries, prose wikilink
- `_index.md` page_count 8→14; health score 75→97/100

## Test plan

- [ ] Wiki pages render correctly (md format valid)
- [ ] No orphan pages or broken wikilinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfDqqrvqqvD3WxVKtruKcB